### PR TITLE
Change HTML interpolations to getters

### DIFF
--- a/src/app/blog-index/blog-index.component.html
+++ b/src/app/blog-index/blog-index.component.html
@@ -1,5 +1,5 @@
 <div class="blog-covers">
-    <!-- <a class="blog-cover" *ngFor="let post of posts" routerLink="/post/{{post.title.replace(' ', '-') | lowercase}}"> -->
+    <!-- TODO: change these HTML interpolations to getters? -->
         <a [ngClass]="isHandsetPortrait ? 'blog-cover-mobile' : 
                       isHandsetLandscape ? 'blog-cover-mobile-landscape' : 
                       'blog-cover'" *ngFor="let post of posts" routerLink="/post/{{post.slug}}">

--- a/src/app/blog-post/blog-post.component.html
+++ b/src/app/blog-post/blog-post.component.html
@@ -1,11 +1,11 @@
 <div [ngClass]="isHandsetPortrait || isHandsetLandscape || isTablet ? 'post__text post__text-mobile':
                 'post__text'">
     <h1 [ngClass]="isHandsetPortrait || isHandsetLandscape ? 'post__title post__title--mobile' :
-                    'post__title'">{{post[0].title}}</h1>
+                    'post__title'">{{postTitle}}</h1>
     <h2 [ngClass]="isHandsetPortrait || isHandsetLandscape ? 'post__subtitle post__subtitle--mobile' : 
-                    'post__subtitle'">{{post[0].subtitle}}</h2>
+                    'post__subtitle'">{{postSubTitle}}</h2>
     <p [ngClass]="isHandsetPortrait || isHandsetLandscape ? 'post__content post__content--mobile' :
-                  'post__content'" [innerText] = "post[0].content"></p>
+                  'post__content'" [innerText] = "postContent"></p>
 </div>
 
 

--- a/src/app/blog-post/blog-post.component.ts
+++ b/src/app/blog-post/blog-post.component.ts
@@ -37,13 +37,25 @@ export class BlogPostComponent {
     this.getPost();
   }
 
+  get postTitle() {
+    return (this.post && this.post[0].title) ? this.post[0].title : null
+  }
+
+  get postSubTitle() {
+    return (this.post[0] && this.post[0].subtitle) ? this.post[0].subtitle : null
+  }
+
+  get postContent() {
+    return (this.post[0] && this.post[0].content) ? this.post[0].content : null
+  }
+
   getPost(): void {
     const slug = String(this.route.snapshot.paramMap.get('slug'));
     this.blogPostService.getPost(slug).subscribe(resp => {
       if (resp[0].photos !== null) {
         this.sortPhotoArray(resp[0])
-        this.post = resp
       }
+      this.post = resp
     })
   }
 

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -8,7 +8,7 @@
                 <li class="navbar__list pointer">
                     <p class="navbar__entry" routerLink="/posts">HOME</p>
                 </li>
-                <li class="navbar__list pointer" *ngFor="let tag of this.tags">
+                <li class="navbar__list pointer" *ngFor="let tag of categoryTags">
                     <p class="navbar__entry" routerLink="/posts/{{tag}}">{{tag.replace('-', ' ') | uppercase}}</p>
                 </li>
                 <li class="navbar__list pointer">
@@ -38,7 +38,7 @@
             <li class="navbar__list pointer">
                 <p class="navbar__entry navbar__entry--mobile" routerLink="/posts" (click)="hideMobileNavModal()">HOME</p>
             </li>
-            <li class="navbar__list pointer" *ngFor="let tag of this.tags">
+            <li class="navbar__list pointer" *ngFor="let tag of categoryTags">
                 <p class="navbar__entry navbar__entry--mobile" routerLink="/posts/{{tag}}" (click)="hideMobileNavModal()">{{tag.replace('-', ' ') | uppercase}}</p>
             </li>
             <li class="navbar__list pointer">

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -43,7 +43,14 @@ export class NavbarComponent {
     this.getPosts();
   }
 
- 
+
+  get categoryTags() {
+    if (this.posts) {
+      return [...new Set(this.posts.map(({tag}) => tag))];
+    } else {
+      return null
+    }
+  }
 
    getPosts(): void { //TODO at the moment we make two API calls for post-index, one for navbar tags 
                       // and one for post mosaic view. Surely we can share the data and only make one API call?
@@ -55,7 +62,6 @@ export class NavbarComponent {
       })
       
       this.posts = resp;
-      this.getTags()
      })
    }
 


### PR DESCRIPTION
We were seeing lots of ctx.post[0] is undefined errors in the console because post[0] was undefined before the observables resolved. Using a getter function allows us to use a ternary operator to return null rather than undefined and catch the error while we wait for the observable to resolve.