### PR TITLE
Gallery modal bugfixes

### DIFF
--- a/src/app/lightbox-gallery/lightbox-gallery.component.css
+++ b/src/app/lightbox-gallery/lightbox-gallery.component.css
@@ -59,6 +59,32 @@
     align-items: center;
 }
 
+
+
+.swiper-slide-prev {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.swiper-slide-prev img {
+    height: fit-content;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.swiper-slide-next {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.swiper-slide-next img {
+    height: fit-content;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 .expandIcon {
     height: 30px;
     width: 30px;

--- a/src/app/lightbox-gallery/lightbox-gallery.component.ts
+++ b/src/app/lightbox-gallery/lightbox-gallery.component.ts
@@ -50,13 +50,10 @@ export class LightboxGalleryComponent {
       this.apiUrl = environment.apiUrl;
       this.previewSwiperEl = document.getElementById("swiper1");
       this.modalSwiperEl = document.getElementById("swiper2");
-
       this.responsiveService.breakpointChanged().subscribe((state) => {
       this.isHandsetPortrait = state.breakpoints[Breakpoints.HandsetPortrait];
       this.isHandsetLandscape = state.breakpoints[Breakpoints.HandsetLandscape];
       this.isWebLandscape = state.breakpoints[Breakpoints.WebLandscape];
-      
-
     })
 
 
@@ -64,6 +61,7 @@ export class LightboxGalleryComponent {
 
     this.initPreviewSwiper()
     this.initModalSwiper()
+    
     // this.addPhotoEventListeners()
   }
 
@@ -135,6 +133,13 @@ export class LightboxGalleryComponent {
     this.modalSwiperEl.initialize();
   }
 
+  goToPreviewView() {
+    this.modalSwiperEl.enabled = false;
+    this.previewSwiperEl.enabled = true;
+    this.previewSwiperEl.swiper.slideTo(this.modalSwiperEl.swiper.activeIndex)
+    this.modalSwiperOn = false;
+    document.getElementsByTagName("body")[0].classList.remove("disabled-scroll") 
+  }
 
   goToModalView() {
     this.previewSwiperEl.enabled = false;
@@ -152,20 +157,23 @@ export class LightboxGalleryComponent {
     // Override browser navigation when modal window is open to close modal
     // window rather than navigating to a new page.
     history.pushState(null, '', window.location.href)
-    this.location.onPopState(() => {                    
-      history.pushState(null, '', window.location.href);
-      this.goToPreviewView()
-    })
+   
+    let foo = () => {     
+      console.log("arrow function popstate event")
+      // history.pushState(null, '', window.location.href);
+      if (this.modalSwiperEl.enabled) {
+        history.pushState(null, '', window.location.href);
+        this.goToPreviewView()
+      }
+      if (this.previewSwiperEl.enabled) {
+        window.removeEventListener('popstate', foo)
+        history.go(-1)
+        // history.back()
+        // history.back()
+      }             
+    }
+    window.addEventListener('popstate', foo)
+
     document.getElementsByTagName("body")[0].classList.add("disabled-scroll")
-
   }
-
-  goToPreviewView() {
-    this.modalSwiperEl.enabled = false;
-    this.previewSwiperEl.enabled = true;
-    this.previewSwiperEl.swiper.slideTo(this.modalSwiperEl.swiper.activeIndex)
-    this.modalSwiperOn = false;
-    document.getElementsByTagName("body")[0].classList.remove("disabled-scroll") 
-  }
-
 }

--- a/src/app/lightbox-gallery/lightbox-gallery.component.ts
+++ b/src/app/lightbox-gallery/lightbox-gallery.component.ts
@@ -136,7 +136,7 @@ export class LightboxGalleryComponent {
   goToPreviewView() {
     this.modalSwiperEl.enabled = false;
     this.previewSwiperEl.enabled = true;
-    this.previewSwiperEl.swiper.slideTo(this.modalSwiperEl.swiper.activeIndex)
+    this.previewSwiperEl.swiper.slideTo(this.modalSwiperEl.swiper.activeIndex, 0)
     this.modalSwiperOn = false;
     document.getElementsByTagName("body")[0].classList.remove("disabled-scroll") 
   }
@@ -144,7 +144,7 @@ export class LightboxGalleryComponent {
   goToModalView() {
     this.previewSwiperEl.enabled = false;
     this.modalSwiperEl.enabled = true;
-    this.modalSwiperEl.swiper.slideTo(this.previewSwiperEl.swiper.activeIndex);
+    this.modalSwiperEl.swiper.slideTo(this.previewSwiperEl.swiper.activeIndex, 0);
     this.modalSwiperOn = true;
     const targetElement = document.getElementById("gallery__item") as HTMLImageElement
     if (!targetElement) {


### PR DESCRIPTION
Fixes the following:

- Images on previous and next swiper slides snapping to oversize on swiper scroll
- Swiper scroll effect to "catch up" when returning to preview swiper view
- Back button behaviour when in modal swiper view
